### PR TITLE
Downgrade to etcd 3.4.26, Upgrade to etcd-backup-restore 0.24.7

### DIFF
--- a/charts/etcd/Chart.yaml
+++ b/charts/etcd/Chart.yaml
@@ -15,5 +15,5 @@
 apiVersion: v1
 description: Helm chart for etcd
 name: garden-etcd
-appVersion: v3.5.2
-version: 5.3.0
+appVersion: v3.4.26
+version: 6.0.0

--- a/charts/etcd/templates/statefulset-etcd.yaml
+++ b/charts/etcd/templates/statefulset-etcd.yaml
@@ -211,7 +211,7 @@ spec:
 {{- end }}
   volumeClaimTemplates:
   - metadata:
-      name: {{ .Values.name }}
+      name: virtual-garden-{{ .Values.name }}
     spec:
       accessModes:
       - "ReadWriteOnce"

--- a/charts/etcd/templates/statefulset-etcd.yaml
+++ b/charts/etcd/templates/statefulset-etcd.yaml
@@ -96,7 +96,7 @@ spec:
             cpu: {{ .Values.resources.limits.cpu | default "1000m" }}
             memory: {{ .Values.resources.limits.memory | default "2560Mi" }}
         volumeMounts:
-        - name: {{ .Values.name }}
+        - name: virtual-garden-{{ .Values.name }}
           mountPath: /var/etcd/data
         - name: etcd-bootstrap
           mountPath: /bootstrap
@@ -174,7 +174,7 @@ spec:
         volumeMounts:
         - name: etcd-bootstrap
           mountPath: /bootstrap
-        - name: {{ .Values.name }}
+        - name: virtual-garden-{{ .Values.name }}
           mountPath: /var/etcd/data
         - name: ca-etcd
           mountPath: /var/etcd/ssl/ca

--- a/charts/etcd/templates/statefulset-etcd.yaml
+++ b/charts/etcd/templates/statefulset-etcd.yaml
@@ -133,9 +133,6 @@ spec:
           requests:
             cpu: 100m
             memory: 128Mi
-          limits:
-            cpu: 300m
-            memory: 1Gi
         securityContext:
           capabilities:
             add:

--- a/charts/etcd/templates/statefulset-etcd.yaml
+++ b/charts/etcd/templates/statefulset-etcd.yaml
@@ -107,8 +107,7 @@ spec:
         - name: etcd-client-tls
           mountPath: /var/etcd/ssl/client
       - name: backup-restore
-        command:
-        - etcdbrctl
+        args:
         - server
         - --schedule={{ .Values.backup.schedule }}
         - --max-backups={{ .Values.backup.maxBackups }}
@@ -137,6 +136,10 @@ spec:
           limits:
             cpu: 300m
             memory: 1Gi
+        securityContext:
+          capabilities:
+            add:
+            - SYS_PTRACE
         env:
         - name: STORAGE_CONTAINER
           value: {{ .Values.backup.storageContainer }}
@@ -146,6 +149,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
         {{- if .Values.backup.storageProvider }}
         {{- if eq .Values.backup.storageProvider "ABS" }}
         - name: AZURE_APPLICATION_CREDENTIALS

--- a/charts/etcd/values.yaml
+++ b/charts/etcd/values.yaml
@@ -15,8 +15,8 @@
 name: etcd
 
 images:
-  etcd: eu.gcr.io/gardener-project/gardener/etcd:v3.5.2
-  etcd-backup-restore: eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.19.0
+  etcd: eu.gcr.io/gardener-project/gardener/etcd:v3.4.26-3
+  etcd-backup-restore: eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.24.7
 
 backup:
   schedule: "0 */24 * * *" # cron standard schedule


### PR DESCRIPTION
This aligns the versions used in this chart with the versions used
currently by gardener/etcd-druid. Even though this introduces breaking
changes, this is required due to compatibility and stability
requirements.

Signed-off-by: Jens Schneider <jens.schneider.ac@posteo.de>