### PR TITLE
Pass through .values.backup.secretData

### DIFF
--- a/charts/etcd/templates/secret-etcd-backup.yaml
+++ b/charts/etcd/templates/secret-etcd-backup.yaml
@@ -20,6 +20,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
+{{ toYaml .Values.backup.secretData | indent 2 }}
   {{- if eq .Values.backup.storageProvider "ABS" }}
   storageAccount: {{ index .Values.backup.secretData "storage-account" }}
   storageKey: {{ index .Values.backup.secretData "storage-key" }}

--- a/charts/etcd/templates/secret-etcd-backup.yaml
+++ b/charts/etcd/templates/secret-etcd-backup.yaml
@@ -21,21 +21,40 @@ metadata:
 type: Opaque
 data:
 {{ toYaml .Values.backup.secretData | indent 2 }}
+
   {{- if eq .Values.backup.storageProvider "ABS" }}
+  {{- if index .Values.backup.secretData "storage-account" }}
   storageAccount: {{ index .Values.backup.secretData "storage-account" }}
+  {{- end }}
+  {{- if index .Values.backup.secretData "storage-key" }}
   storageKey: {{ index .Values.backup.secretData "storage-key" }}
   {{- end }}
-  {{- if eq .Values.backup.storageProvider "Swift" }}
-  authURL: {{ index .Values.backup.secretData "auth-url" }}
-  domainName: {{ index .Values.backup.secretData "domain-name" }}
-  password: {{ index .Values.backup.secretData "password" }}
-  region: {{ index .Values.backup.secretData "region-name" }}
-  tenantName: {{ index .Values.backup.secretData "project-name" }}
-  username:  {{ index .Values.backup.secretData "username" }}
   {{- end }}
+
+  {{- if eq .Values.backup.storageProvider "Swift" }}
+  {{- if index .Values.backup.secretData "auth-url" }}
+  authURL: {{ index .Values.backup.secretData "auth-url" }}
+  {{- end }}
+  {{- if index .Values.backup.secretData "domain-name" }}
+  domainName: {{ index .Values.backup.secretData "domain-name" }}
+  {{- end }}
+  {{- if index .Values.backup.secretData "region-name" }}
+  region: {{ index .Values.backup.secretData "region-name" }}
+  {{- end }}
+  {{- if index .Values.backup.secretData "project-name" }}
+  tenantName: {{ index .Values.backup.secretData "project-name" }}
+  {{- end }}
+  {{- end }}
+
   {{- if eq .Values.backup.storageProvider "S3" }}
+  {{- if index .Values.backup.secretData "access-key-id" }}
   accessKeyID: {{ index .Values.backup.secretData "access-key-id" }}
+  {{- end }}
+  {{- if index .Values.backup.secretData "secret-access-key" }}
   secretAccessKey: {{ index .Values.backup.secretData "secret-access-key" }}
+  {{- end }}
+  {{- if index .Values.backup.secretData "region" }}
   region: {{ index .Values.backup.secretData "region" }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/etcd/templates/secret-etcd-backup.yaml
+++ b/charts/etcd/templates/secret-etcd-backup.yaml
@@ -53,8 +53,5 @@ data:
   {{- if index .Values.backup.secretData "secret-access-key" }}
   secretAccessKey: {{ index .Values.backup.secretData "secret-access-key" }}
   {{- end }}
-  {{- if index .Values.backup.secretData "region" }}
-  region: {{ index .Values.backup.secretData "region" }}
-  {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Reverts #11.

Passing through is the easiest way to support any credentials that etcd-backup-restore supports. Noop rewrites were removed.

Edit: I think we should get rid of these rewrites altogether if possible.