### PR TITLE
Add option to set stringData in backup secret

### DIFF
--- a/charts/etcd/templates/secret-etcd-backup.yaml
+++ b/charts/etcd/templates/secret-etcd-backup.yaml
@@ -19,6 +19,10 @@ metadata:
   name: {{ .Values.name }}-backup
   namespace: {{ .Release.Namespace }}
 type: Opaque
+{{- with .Values.backup.secretStringData }}
+stringData:
+{{- toYaml . | nindent 2 }}
+{{- end }}
 data:
 {{ toYaml .Values.backup.secretData | indent 2 }}
 

--- a/charts/etcd/values.yaml
+++ b/charts/etcd/values.yaml
@@ -27,11 +27,12 @@ etcd-backup-restore:
 backup:
   schedule: "0 */24 * * *" # cron standard schedule
   maxBackups: 7 # Maximum number of backups to keep (may change in future)
-  storageProvider: ""  # Abs,Gcs,S3,Swift empty means no backup,
+  storageProvider: "" # Abs,Gcs,S3,Swift empty means no backup,
   secretData: {}
+  secretStringData: {}
   storageContainer: ""
   volumeMounts: []
-# storePrefix: "custom-prefix"
+  # storePrefix: "custom-prefix"
   env: [] # allows setting custom env vars
 
 tls:


### PR DESCRIPTION
#15 re-introduced the option to pass through any key-value data to the backup secret. Unfortunately, this requires the data to be already base64 encoded, which is not always feasible / easy to provide.

This small change adds an additional field `backup.secretStringData` which is passed as `stringData` into the secret. 