### PR TITLE
Add option to override the volume name

### DIFF
--- a/charts/etcd/templates/_helper.tpl
+++ b/charts/etcd/templates/_helper.tpl
@@ -1,0 +1,7 @@
+{{- define "dataVolumeName" -}}
+{{- if (.Values.volumeClaimNameOverride) -}}
+{{ .Values.volumeClaimNameOverride }}
+{{- else -}}
+virtual-garden-{{ .Values.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/etcd/templates/statefulset-etcd.yaml
+++ b/charts/etcd/templates/statefulset-etcd.yaml
@@ -96,7 +96,7 @@ spec:
             cpu: {{ .Values.resources.limits.cpu | default "1000m" }}
             memory: {{ .Values.resources.limits.memory | default "2560Mi" }}
         volumeMounts:
-        - name: virtual-garden-{{ .Values.name }}
+        - name: {{ template "dataVolumeName" . }}
           mountPath: /var/etcd/data
         - name: etcd-bootstrap
           mountPath: /bootstrap
@@ -171,7 +171,7 @@ spec:
         volumeMounts:
         - name: etcd-bootstrap
           mountPath: /bootstrap
-        - name: virtual-garden-{{ .Values.name }}
+        - name: {{ template "dataVolumeName" . }}
           mountPath: /var/etcd/data
         - name: ca-etcd
           mountPath: /var/etcd/ssl/ca
@@ -208,7 +208,7 @@ spec:
 {{- end }}
   volumeClaimTemplates:
   - metadata:
-      name: virtual-garden-{{ .Values.name }}
+      name: {{ template "dataVolumeName" . }}
     spec:
       accessModes:
       - "ReadWriteOnce"

--- a/charts/etcd/values.yaml
+++ b/charts/etcd/values.yaml
@@ -56,3 +56,5 @@ resources:
 volumeClaimTemplates:
   requests:
     storage: 10Gi
+
+volumeClaimNameOverride: "" # override name of volumeClaim. Defaults to `virtual-garden-{{ .Values.name }}`


### PR DESCRIPTION
In #13 the volume was changed from `{{ .Values.name }}` to  `gardener-virtual-{{ .Values.name }}` . This breaking change can lead to problems, requiring manual migrations.

I would like to propose adding the option to provide a custom name, so that one can e.g. keep the old name.